### PR TITLE
feat: add more valid languages

### DIFF
--- a/leetcode_export/utils.py
+++ b/leetcode_export/utils.py
@@ -23,6 +23,11 @@ VALID_PROGRAMMING_LANGUAGES = [
     "ruby",
     "bash",
     "swift",
+    "typescript",
+    "elixir",
+    "erlang",
+    "racket",
+    "dart",
 ]
 
 FILE_EXTENSIONS = {
@@ -47,6 +52,11 @@ FILE_EXTENSIONS = {
     "ruby": "rb",
     "bash": "sh",
     "swift": "swift",
+    "typescript": "ts",
+    "elixir": "ex",
+    "erlang": "erl",
+    "racket": "rkt",
+    "dart": "dart",
 }
 
 SPECIAL_CHARACTERS_FILENAME = ["/", "\\", ":", "*", "?", '"', '"', "<", ">", "|"]


### PR DESCRIPTION
Add more valid languages

previously I encountered error when running the tool because typescript is not valid although it's actually valid.

then I found there are couple other languages missing and created a PR here