### PR TITLE
add support for incremental updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ usage: leetcode-export [-h] [--cookies COOKIES] [--folder FOLDER]
                        [--problem-statement-content PROBLEM_STATEMENT_CONTENT]
                        [--submission-filename SUBMISSION_FILENAME]
                        [--only-accepted] [--only-last-submission]
-                       [--language LANGUAGE_UNPROCESSED] [-v] [-vv] [-V]
+                       [--language LANGUAGE_UNPROCESSED]
+                       [--checkpoint-file CHECKPOINT_FILE] [-v] [-vv] [-V]
 
 Export LeetCode submissions
 
@@ -144,10 +145,48 @@ options:
                                    html, php, golang, scala, pythonml,
                                    rust, ruby, bash, swift
                         example: --language=python,cpp,java
+  --checkpoint-file CHECKPOINT_FILE
+                        path to checkpoint file for incremental backups (stores Unix 
+                        timestamp of newest processed submission)
   -v, --verbose         enable verbose logging details
   -vv, --extra-verbose  enable more verbose logging details
   -V, --version         show program's version number and exit
 ```
+
+### Incremental Backups
+
+The `--checkpoint-file` option enables incremental backups by storing the timestamp of the newest processed submission. This allows you to run the script multiple times and only download new submissions since the last run, making it much faster for regular backups.
+
+#### How it works
+
+1. **First run**: If the checkpoint file doesn't exist, the script will prompt you to create it and perform a full backup
+2. **Subsequent runs**: The script reads the timestamp from the checkpoint file and only processes submissions newer than that timestamp
+3. **Automatic updates**: The checkpoint file is updated automatically at the end of a successful run with the timestamp of the newest submission processed
+
+#### Example usage
+
+```bash
+# First run - full backup
+leetcode-export \
+  --folder ./submissions \
+  --checkpoint-file ~/.leetcode_checkpoint \
+  --only-accepted \
+  --cookies "your_cookies_here"
+
+# Subsequent runs - only new submissions
+leetcode-export \
+  --folder ./submissions \
+  --checkpoint-file ~/.leetcode_checkpoint \
+  --only-accepted \
+  --cookies "your_cookies_here"
+```
+
+#### Important notes
+
+- The checkpoint file stores a Unix timestamp of the newest processed submission
+- Only submissions that are actually written to disk (not filtered out) update the checkpoint
+- If no new submissions are found, the checkpoint file remains unchanged
+- The script will stop early when it reaches submissions older than the checkpoint, making it very efficient
 
 ### Problem template arguments
 

--- a/leetcode_export/__main__.py
+++ b/leetcode_export/__main__.py
@@ -166,6 +166,7 @@ def main():
         logging.info("Output folder not found, creating it")
         os.mkdir(args.folder)
     os.chdir(args.folder)
+    base_folder = os.getcwd()
 
     title_slug_to_problem_folder_name: dict[str, str] = dict()
     title_slug_to_exported_languages: dict[str, set[str]] = dict()
@@ -220,7 +221,7 @@ def main():
                 problem_folder_name
             )
             if not os.path.exists(problem_folder_name):
-                os.mkdir(problem_folder_name)
+                os.makedirs(problem_folder_name, exist_ok=True)
             os.chdir(problem_folder_name)
 
             problem_statement_filename = problem_statement_filename_template.substitute(
@@ -251,7 +252,7 @@ def main():
                 f"{submission.title_slug}/{submission_filename} already exists, skipping it"
             )
 
-        os.chdir("..")
+        os.chdir(base_folder)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Incremental Backup Feature - Pull Request Summary

### Overview

Added --checkpoint-file functionality to enable incremental backups, significantly reducing backup time for users who run the script regularly. **This is an optional flag**

### Problem Solved

  Previously, every run was a full backup, requiring downloading all submissions regardless of whether they had been processed before. This made regular backups slower than necessary.

### Solution

The checkpoint feature stores the Unix timestamp of the newest processed submission. Subsequent runs only process submissions newer than the checkpoint, leveraging LeetCode's reverse chronological API ordering to stop early when reaching older submissions.

### Key Features

  - Efficient: Stops API pagination early when reaching older submissions
  - Safe: Only updates checkpoint after successful completion of entire script to prevent over-checkpointing
  - User-friendly: Prompts for confirmation when creating new checkpoint files
  - Respects filters: Only updates checkpoint when submissions are actually written (honors --only-accepted, --language, etc.)

### Usage

  ```
leetcode-export --checkpoint-file ~/.leetcode_checkpoint --only-accepted
```

### Implementation Details

  - Stores Unix timestamps for timezone-agnostic operation
  - Updates checkpoint atomically at end of successful runs only
  - Maintains backward compatibility (optional feature)
  - Comprehensive error handling and logging

  This feature makes regular LeetCode backups practical for active users while maintaining the robustness of the existing codebase.